### PR TITLE
Add ScrollToHideController

### DIFF
--- a/lib/src/scroll_to_hide.dart
+++ b/lib/src/scroll_to_hide.dart
@@ -23,6 +23,7 @@ class ScrollToHide extends StatefulWidget {
     required this.hideDirection,
     this.width,
     this.height,
+    this.controller,
   });
 
   /// The widget that you want to hide/show based on the scroll direction.
@@ -44,6 +45,9 @@ class ScrollToHide extends StatefulWidget {
   /// The initial width of the child widget, its width will be animated to 0 .by providing width you want the hide direction to be horizontal.
   final double? width;
 
+  /// Allows to easily show or hide the child
+  final ScrollToHideController? controller;
+
   @override
   State<ScrollToHide> createState() => _ScrollToHideState();
 }
@@ -53,6 +57,7 @@ class _ScrollToHideState extends State<ScrollToHide> {
 
   @override
   void initState() {
+    widget.controller?._attach(this);
     widget.scrollController.addListener(listen);
     super.initState();
   }
@@ -110,4 +115,17 @@ class _ScrollToHideState extends State<ScrollToHide> {
       hide();
     }
   }
+}
+
+
+/// Allows to easily show or hide the child
+class ScrollToHideController {
+  _ScrollToHideState? _state;
+
+  void _attach(_ScrollToHideState state) {
+    _state = state;
+  }
+
+  void show() => _state?.show();
+  void hide() => _state?.hide();
 }


### PR DESCRIPTION
Add `ScrollToHideController` to conveniently show or hide the child.

We can use `ScrollToHide` widget as before or we can add `ScrollToHideController` to its parameters like this:

```dart
// Initialize the controller
final controller = ScrollToHideController();

ScrollToHide(
  scrollController: _yourScrollController,
  height: _desiredHeight, // The initial height of the widget.
  duration: Duration(milliseconds: 300), // Duration of the hide/show animation.
  controller: controller, // Place the controller here
  child: YourWidgetToHide(),
),

// Use controller to show or hide the child widget
controller.show();
// ...
controller.hide();
```

We can also use the controller with state managers like GetX.

```dart
// Store the controller
Get.put(ScrollToHideController());

// Then (from any place of your app)
Get.find<ScrollToHideController>().show();
//...
Get.find<ScrollToHideController>().hide();
```